### PR TITLE
Error handling of Delete method

### DIFF
--- a/rules/rules.go
+++ b/rules/rules.go
@@ -92,6 +92,9 @@ func (t *rules) Delete(req DeleteRulesRequest, dryRun bool) (*TwitterRuleRespons
 
 	res, err := t.httpClient.AddRules(t.addDryRun(dryRun), string(body))
 
+	if err != nil {
+		return nil, err
+	}
 
 	defer res.Body.Close()
 	data := new(TwitterRuleResponse)


### PR DESCRIPTION
I fixed an error handling omission in the Delete method that causes panic in `res.Body.Close()` on HTTP request failure.